### PR TITLE
Adjust style to match MantisBT 2.*.*

### DIFF
--- a/Taskodrome/files/scripts/grid_draw_utils.js
+++ b/Taskodrome/files/scripts/grid_draw_utils.js
@@ -4,8 +4,8 @@ var V_OFFSET = 20;
 var CARD_H_OFFSET = 15;
 var CARD_V_OFFSET = 10;
 
-var FONT_COLOR = "#000000"
-var FONT_FAMILY = "Arial"
+var FONT_COLOR = "#393939"
+var FONT_FAMILY = "Open Sans"
 var FONT_SIZE = "12px"
 var FONT = FONT_SIZE + " " + FONT_FAMILY;
 
@@ -347,8 +347,8 @@ function createColumns(columnNames, number, width, height) {
   for(var i = 0; i <= number; ++i) {
     var startX = H_OFFSET + i * width;
     var line = new createjs.Shape();
-    line.graphics.setStrokeStyle(2, 2);
-    line.graphics.beginStroke(createjs.Graphics.getRGB(0,0,0));
+    line.graphics.setStrokeStyle(2);
+    line.graphics.beginStroke("#b3cbd8");
     line.graphics.moveTo(startX, V_OFFSET);
     line.graphics.lineTo(startX, height + V_OFFSET);
     columns.addChild(line);
@@ -369,9 +369,9 @@ function createColumns(columnNames, number, width, height) {
 function createCardBack(width, height) {
   var back = new createjs.Shape();
   back.graphics.setStrokeStyle(1);
-  back.graphics.beginStroke("#000000");
+  back.graphics.beginStroke("#bfd5e1");
   back.graphics.beginFill("#F0F5FF");
-  back.graphics.drawRect(0, 0, width, height);
+  back.graphics.drawRoundRect(0, 0, width, height, 3, 3 ,3, 3);
   return back;
 };
 
@@ -395,7 +395,7 @@ function createCardBottomMark(markColor, cardWidth, cardHeight, markWidth) {
 
 function createCardNumber(issueNumber, width, markWidth) {
   var cont = new createjs.Container();
-  var numberColor = "#0000FF";
+  var numberColor = "#4C8FBD";
   var number = new createjs.Text(issueNumber, FONT, numberColor);
   number.x = width - number.getBounds().width - 5;
   number.y += markWidth + 3;

--- a/Taskodrome/files/taskodrome.css
+++ b/Taskodrome/files/taskodrome.css
@@ -1,10 +1,13 @@
-div.grid { 
-  position: relative; 
-  padding: 0px; 
+div.grid {
+  position: relative;
+  padding: 0px;
   left: -6px;
   height: auto;
   min-height: 500px;
   overflow: auto;
+  background-color: #E7F2F8;
+  margin: 6px;
+  border-radius: 3px;
 }
 
 .tabs {
@@ -54,14 +57,13 @@ div.grid {
 
 #radio_dg:checked ~ #label_dg,
 #radio_sg:checked ~ #label_sg {
-  color: purple;
+  font-weight: bolder;
 }
 
 .radio_label {
-  text-decoration: underline;
-  color: blue;
+  color: #4C8FBD;
 }
 
 .radio_label:hover {
-  color: red;
+  text-decoration: underline;
 }


### PR DESCRIPTION
This merge request changes a few styles in the .css and grid_draw_utils.js to change taskodrome to feel more like it belongs in the new MantisBT 2.*.* style.

Screenshots: 
![image](https://cloud.githubusercontent.com/assets/7538787/25143865/ed74dfa2-2463-11e7-8718-9ed9e39bfab1.png)
![image](https://cloud.githubusercontent.com/assets/7538787/25143874/f7546fce-2463-11e7-82b8-c54f27ba5adb.png)
