### PR TITLE
Fix "TypeError: issue is undefined"

### DIFF
--- a/Taskodrome/files/scripts/relationship_grid.js
+++ b/Taskodrome/files/scripts/relationship_grid.js
@@ -141,6 +141,9 @@ function createMappedIsseuesWithRelations_rl(rels) {
     var src_id = item.src_bug_id.toString();
     var dest_id = item.dest_bug_id.toString();
 
+    if ( item[src_id] == undefined || item[dest_id] == undefined )
+        return;
+    
     if (ret[src_id] == undefined) {
       ret[src_id] = { issue : item[src_id], children : [], isChild : false };
     }


### PR DESCRIPTION
When some issue is hidden, for example a closed issue. The relationship map cannot find the issue and result in a "TypeError: issue is undefined".
Because the related issue is hidden, the relationship is removed to fix this bug.