### PR TITLE
Fix in non-ANSI language, status board cannot be shown

### DIFF
--- a/Taskodrome/files/scripts/status_grid.js
+++ b/Taskodrome/files/scripts/status_grid.js
@@ -117,9 +117,7 @@ function createColumnStatusMap() {
   }
 
   for (var i = 0; i != m_statusList.length; ++i) {
-    var status = m_statusList[i];
-    var statusNameL = status.toLowerCase();
-    m_statusByColumns[i] = statusCodes[statusNameL];
+    m_statusByColumns[i] = statusCodes[i];
   }
 
   for (var i = 0; i != 91; ++i) {
@@ -169,18 +167,15 @@ function getStatusList_st() {
   return ret;
 };
 
+//return status code sort by status in the config
 function getStatusCodes_st() {
   var ret = [];
-  var statusNameMap = document.getElementsByClassName("status_name_map")[0].getAttribute("value");
-  if (!checkExistence("getStatusCodes_st", statusNameMap)) {
+  var statusCode = document.getElementsByClassName("status_name_map")[0].getAttribute("value");
+  if (!checkExistence("getStatusCodes_st", statusCode)) {
     return ret;
   }
-  var pairs = statusNameMap.split(';');
-
-  for (var i = 0, l = pairs.length; i != l - 1; ++i) {
-    var pair = pairs[i].split(':');
-    ret[pair[1].toLowerCase()] = pair[0];
-  }
+  var ret = statusCode.split(';');
+  ret = ret.splice(0, ret.length - 1);
 
   return ret;
 };

--- a/Taskodrome/files/scripts/status_grid.js
+++ b/Taskodrome/files/scripts/status_grid.js
@@ -170,7 +170,7 @@ function getStatusList_st() {
 //return status code sort by status in the config
 function getStatusCodes_st() {
   var ret = [];
-  var statusCode = document.getElementsByClassName("status_name_map")[0].getAttribute("value");
+  var statusCode = document.getElementsByClassName("status_code_order")[0].getAttribute("value");
   if (!checkExistence("getStatusCodes_st", statusCode)) {
     return ret;
   }

--- a/Taskodrome/pages/main.php
+++ b/Taskodrome/pages/main.php
@@ -160,7 +160,25 @@
       print '<p class="version" value="'.version_get_field($ver_id, "version").'"></p>';
     }
 
+    $status_code = null;
+    $status_name = explode( ';' , $status_order );
+    $t_enum_statuses = config_get( 'status_enum_string' );
+    $t_statuses = explode( ',', $t_enum_statuses );
+    $t_status_array = array();
+    foreach( $t_statuses as $t_status  ) {
+        $t_status_array[] = explode( ':', $t_status );
+    }
+    
+    foreach( $status_name as $t_name ) {
+        for ( $i = 0 ; $i < sizeof($t_status_array) ; $i++ ){
+            if ( 0 == strcmp($t_name, $t_status_array[$i][1]) ){
+                $status_code .= $t_status_array[$i][0] . ';';
+            }
+        }
+    }
+    
     print '<p class="status_board_order" value="'.$status_order.'"></p>';
+    print '<p class="status_code_order" value="'.$status_code.'"></p>';
     print '<p id="auto_set_status_to_assigned" value="'. config_get( "auto_set_status_to_assigned" ) .'"></p>';
     print '<p id="cooldown_period_days" value="'. plugin_config_get("cooldown_period_days", null, false, null, $current_project_id) .'"></p>';
     print '<p id="cooldown_period_hours" value="'. plugin_config_get("cooldown_period_hours", null, false, null, $current_project_id) .'"></p>';


### PR DESCRIPTION
The statusNameL may contain non-ANSI characters, which cannot be used as array index.
The status code needed for m_statusByColumns is directly calculated by PHP. 