### PR TITLE
Added language support

### DIFF
--- a/Taskodrome/Taskodrome.php
+++ b/Taskodrome/Taskodrome.php
@@ -41,10 +41,12 @@ class TaskodromePlugin extends MantisPlugin
 
   public function config()
   {
-    $status_list = explode(',', lang_get( 'status_enum_string' ));
-    foreach( $status_list as $key => $value ) {
-      $status_list[$key] = substr($value, strpos($value, ':') + 1);
-    }
+    $status_list = explode(',', config_get('status_enum_string') );
+  
+      foreach( $status_list as $key => $value ) {
+        $status_list[$key] = explode(':', $value)[0];
+      } 
+
     return array(
       "status_board_order_default" => $status_list,
       "status_board_order" => $status_list,

--- a/Taskodrome/core/config_helper.php
+++ b/Taskodrome/core/config_helper.php
@@ -1,0 +1,17 @@
+<?php
+
+function convertStatusEnumToString($p_StatusEnumList){
+    $t_StatusEnumList = $p_StatusEnumList;
+    $t_status_list_language = explode(',', lang_get( 'status_enum_string' ));
+    $t_status_enum_lang_array = array();
+
+    foreach( $t_status_list_language as $key => $value ) {
+        $t_status_enum_lang_array[explode(':', $value)[0]] = explode(':', $value)[1];
+    } 
+
+    foreach($t_StatusEnumList as $key => $value) {
+        $t_StatusEnumList[$key] = $t_status_enum_lang_array[explode(':', $value)[0]];
+    }
+
+    return $t_StatusEnumList;
+}

--- a/Taskodrome/pages/config_page.php
+++ b/Taskodrome/pages/config_page.php
@@ -5,7 +5,7 @@
 
 auth_reauthenticate();
 access_ensure_global_level( config_get( 'manage_plugin_threshold' ) );
-
+require_once( config_get( 'plugin_path' ) . 'Taskodrome/core/config_helper.php' );
 layout_page_header( plugin_lang_get( 'config_title' ) );
 
 layout_page_begin( 'manage_overview_page.php' );
@@ -42,14 +42,14 @@ print_manage_menu( 'manage_plugin_page.php' );
                     </br>
                     <span class="small">
                       <?php printf( plugin_lang_get( 'default_value' ),
-                      string_attribute( implode( ';', plugin_config_get( $t_field . '_default') ) ));
+                      string_attribute( implode( ';', convertStatusEnumToString(plugin_config_get( $t_field . '_default') )) ));
                     ?>
                     </span>
                   </th>
                   <td class="center" width="20%">
                     <span class="input">
                       <input name="<?php echo $t_field; ?>" size="75" type="text" value="<?php
-                        $t_config = plugin_config_get( $t_field, null, false, null, helper_get_current_project() );
+                        $t_config = convertStatusEnumToString(plugin_config_get( $t_field, null, false, null, helper_get_current_project()) );
                         $t_encoded = '';
                         foreach( $t_config as $t_value ) {
                           $t_encoded .= "$t_value;";

--- a/Taskodrome/pages/main.php
+++ b/Taskodrome/pages/main.php
@@ -1,7 +1,7 @@
 <?php
 
   html_robots_noindex();
-
+  require_once( config_get( 'plugin_path' ) . 'Taskodrome/core/config_helper.php' );
   layout_page_header_begin(plugin_lang_get( 'board' ));
 
   print "<link rel=\"stylesheet\" type=\"text/css\" href=\"".plugin_file('taskodrome.css')."\" />\n";
@@ -159,7 +159,7 @@
     print '<p class="status_color_map" value="'.$status_color_map.'"></p>';
 
     $status_order = null;
-    foreach( plugin_config_get("status_board_order", null, false, null, $current_project_id) as $t_value ) {
+    foreach( convertStatusEnumToString( plugin_config_get("status_board_order", null, false, null, $current_project_id)) as $t_value ) {
       $status_order .= $t_value.';';
     }
 


### PR DESCRIPTION
When a language is used which is different from the admin which installed this plugin, none or not all tickets are shown for users which have a different language then the admin. This pull fixed that issue by using the enum-value, instead of using the language specific strings,