### PR TITLE
Added Function to Convert Strings back to Enum

### DIFF
--- a/Taskodrome/core/config_helper.php
+++ b/Taskodrome/core/config_helper.php
@@ -1,17 +1,34 @@
 <?php
 
 function convertStatusEnumToString($p_StatusEnumList){
-    $t_StatusEnumList = $p_StatusEnumList;
+    $t_StatusStringList = $p_StatusEnumList;
+    $t_status_enum_lang_array = getLanguageListForEnum();
+
+    foreach($t_StatusStringList as $key => $value) {
+        $t_StatusStringList[$key] = $t_status_enum_lang_array[explode(':', $value)[0]];
+    }
+
+    return $t_StatusStringList;
+}
+
+function convertStringToStatusEnum($p_StringList){
+    $t_StatusEnumList = $p_StringList;
+    $t_status_lang_enum_array = array_flip(getLanguageListForEnum());
+    
+    foreach($t_StatusEnumList as $key => $value) {
+        $t_StatusEnumList[$key] = $t_status_lang_enum_array[explode(':', $value)[0]];
+    }
+    
+    return $t_StatusEnumList;
+}
+
+function getLanguageListForEnum(){
     $t_status_list_language = explode(',', lang_get( 'status_enum_string' ));
     $t_status_enum_lang_array = array();
-
+   
     foreach( $t_status_list_language as $key => $value ) {
         $t_status_enum_lang_array[explode(':', $value)[0]] = explode(':', $value)[1];
     } 
-
-    foreach($t_StatusEnumList as $key => $value) {
-        $t_StatusEnumList[$key] = $t_status_enum_lang_array[explode(':', $value)[0]];
-    }
-
-    return $t_StatusEnumList;
+    
+    return $t_status_enum_lang_array;
 }

--- a/Taskodrome/pages/config.php
+++ b/Taskodrome/pages/config.php
@@ -4,11 +4,12 @@ form_security_validate( 'plugin_format_config_edit' );
 
 auth_reauthenticate( );
 access_ensure_global_level( config_get( 'manage_plugin_threshold' ) );
+require_once( config_get( 'plugin_path' ) . 'Taskodrome/core/config_helper.php' );
 
 $f_status_order = gpc_get_string( 'status_board_order' );
 
 if( plugin_config_get( 'status_board_order', null, false, null, helper_get_current_project() ) != $f_status_order ) {
-  plugin_config_set( 'status_board_order', explode(';', $f_status_order), NO_USER, helper_get_current_project() );
+ plugin_config_set( 'status_board_order', convertStringToStatusEnum(explode(';', $f_status_order)), NO_USER, helper_get_current_project() );
 }
 
 $f_cooldown_period_days = gpc_get_int( 'cooldown_period_days' );


### PR DESCRIPTION
Hi,

I forget to a a function which converting strings back to enum (sry!). With out it is not possible to store a new status order in the config.